### PR TITLE
sw_apps: zynqmp_fsbl: Mark both RPU cores as used when running in loc…

### DIFF
--- a/lib/sw_apps/zynqmp_fsbl/src/xfsbl_main.c
+++ b/lib/sw_apps/zynqmp_fsbl/src/xfsbl_main.c
@@ -621,9 +621,13 @@ static void XFsbl_MarkUsedRPUCores(XFsblPs *FsblInstPtr, u32 PartitionNum)
 	 */
 	switch (DestCpu) {
 	case XIH_PH_ATTRB_DEST_CPU_R5_0:
-	case XIH_PH_ATTRB_DEST_CPU_R5_L:
 		Xil_Out32(XFSBL_R5_USAGE_STATUS_REG, RegValue |
 			  XFSBL_R5_0_STATUS_MASK);
+		break;
+	case XIH_PH_ATTRB_DEST_CPU_R5_L:
+		/* Lockstep runs on both cores */
+		Xil_Out32(XFSBL_R5_USAGE_STATUS_REG, RegValue |
+			  XFSBL_R5_0_STATUS_MASK | XFSBL_R5_1_STATUS_MASK);
 		break;
 	case XIH_PH_ATTRB_DEST_CPU_R5_1:
 		Xil_Out32(XFSBL_R5_USAGE_STATUS_REG, RegValue |


### PR DESCRIPTION
## Problem

When the FSBL loads a partition destined for the RPU in lockstep mode (`XIH_PH_ATTRB_DEST_CPU_R5_L`), `XFsbl_MarkUsedRPUCores()` only set the RPU0 usage bit in `XFSBL_R5_USAGE_STATUS_REG`, because the lockstep case fell through to the same handling as `XIH_PH_ATTRB_DEST_CPU_R5_0`.

The PMU firmware uses this register to decide which RPU cores it may power down. With `ENABLE_UNUSED_RPU_PWR_DWN` enabled, `PmForceDownUnusableRpuCores()` runs as soon as any master calls `pm_init_finalize` — for example the Linux ZynqMP power driver during boot. Since the RPU1 usage bit was never set, pmufw treated RPU1 as unused and released its power-island, clock, and master requirements, even though in lockstep mode both cores execute the application together. As a result, RPU1 was disabled underneath a running lockstep application.

## Fix

Give `XIH_PH_ATTRB_DEST_CPU_R5_L` its own case in `XFsbl_MarkUsedRPUCores()` that sets both the RPU0 and RPU1 usage bits, so pmufw keeps both cores alive.