### PR TITLE
rfdc: fall back to config struct when tile/block/path enable register…

### DIFF
--- a/XilinxProcessorIPLib/drivers/rfdc/src/xrfdc.c
+++ b/XilinxProcessorIPLib/drivers/rfdc/src/xrfdc.c
@@ -2376,7 +2376,13 @@ u32 XRFdc_CheckTileEnabled(XRFdc *InstancePtr, u32 Type, u32 Tile_Id)
 	}
 
 	if ((TileEnableReg & TileMask) == 0U) {
-		Status = XRFDC_FAILURE;
+		/* Older RFdc IP generations (e.g. Gen1 XCZU27DR) do not populate
+		 * XRFDC_TILES_ENABLED_OFFSET, so it reads 0. Fall back to the
+		 * config structure as pre-2019 drivers did. */
+		u32 CfgEnable = (Type == XRFDC_ADC_TILE) ?
+				InstancePtr->RFdc_Config.ADCTile_Config[Tile_Id].Enable :
+				InstancePtr->RFdc_Config.DACTile_Config[Tile_Id].Enable;
+		Status = (CfgEnable == 0U) ? XRFDC_FAILURE : XRFDC_SUCCESS;
 	} else {
 		Status = XRFDC_SUCCESS;
 	}

--- a/XilinxProcessorIPLib/drivers/rfdc/src/xrfdc_ap.c
+++ b/XilinxProcessorIPLib/drivers/rfdc/src/xrfdc_ap.c
@@ -3125,6 +3125,11 @@ u32 XRFdc_IsDACBlockEnabled(XRFdc *InstancePtr, u32 Tile_Id, u32 Block_Id)
 	BlockEnableReg = XRFdc_ReadReg(InstancePtr, XRFDC_IP_BASE, XRFDC_DAC_PATHS_ENABLED_OFFSET);
 	BlockEnableReg &= (XRFDC_ENABLED << BlockShift);
 	IsBlockAvail = BlockEnableReg >> BlockShift;
+	if (IsBlockAvail == 0U) {
+		/* Older RFdc IP does not populate XRFDC_DAC_PATHS_ENABLED_OFFSET.
+		 * Fall back to the config structure. */
+		IsBlockAvail = InstancePtr->RFdc_Config.DACTile_Config[Tile_Id].DACBlock_Analog_Config[Block_Id].BlockAvailable;
+	}
 	return IsBlockAvail;
 }
 
@@ -3175,6 +3180,11 @@ u32 XRFdc_IsADCBlockEnabled(XRFdc *InstancePtr, u32 Tile_Id, u32 Block_Id)
 	BlockEnableReg = XRFdc_ReadReg(InstancePtr, XRFDC_IP_BASE, XRFDC_ADC_PATHS_ENABLED_OFFSET);
 	BlockEnableReg &= (XRFDC_ENABLED << BlockShift);
 	IsBlockAvail = BlockEnableReg >> BlockShift;
+	if (IsBlockAvail == 0U) {
+		/* Older RFdc IP does not populate XRFDC_ADC_PATHS_ENABLED_OFFSET.
+		 * Fall back to the config structure. */
+		IsBlockAvail = InstancePtr->RFdc_Config.ADCTile_Config[Tile_Id].ADCBlock_Analog_Config[Block_Id].BlockAvailable;
+	}
 
 RETURN_PATH:
 	return IsBlockAvail;

--- a/XilinxProcessorIPLib/drivers/rfdc/src/xrfdc_dp.c
+++ b/XilinxProcessorIPLib/drivers/rfdc/src/xrfdc_dp.c
@@ -803,6 +803,11 @@ u32 XRFdc_IsDACDigitalPathEnabled(XRFdc *InstancePtr, u32 Tile_Id, u32 Block_Id)
 	DigitalPathEnableReg = XRFdc_ReadReg(InstancePtr, XRFDC_IP_BASE, XRFDC_DAC_PATHS_ENABLED_OFFSET);
 	DigitalPathEnableReg &= (XRFDC_ENABLED << DigitalPathShift);
 	IsDigitalPathAvail = DigitalPathEnableReg >> DigitalPathShift;
+	if (IsDigitalPathAvail == 0U) {
+		/* Older RFdc IP does not populate XRFDC_DAC_PATHS_ENABLED_OFFSET.
+		 * Fall back to the config structure. */
+		IsDigitalPathAvail = InstancePtr->RFdc_Config.DACTile_Config[Tile_Id].DACBlock_Analog_Config[Block_Id].BlockAvailable;
+	}
 	return IsDigitalPathAvail;
 }
 
@@ -840,6 +845,11 @@ u32 XRFdc_IsADCDigitalPathEnabled(XRFdc *InstancePtr, u32 Tile_Id, u32 Block_Id)
 	DigitalPathEnableReg = XRFdc_ReadReg(InstancePtr, XRFDC_IP_BASE, XRFDC_ADC_PATHS_ENABLED_OFFSET);
 	DigitalPathEnableReg &= (XRFDC_ENABLED << DigitalPathShift);
 	IsDigitalPathAvail = DigitalPathEnableReg >> DigitalPathShift;
+	if (IsDigitalPathAvail == 0U) {
+		/* Older RFdc IP does not populate XRFDC_ADC_PATHS_ENABLED_OFFSET.
+		 * Fall back to the config structure. */
+		IsDigitalPathAvail = InstancePtr->RFdc_Config.ADCTile_Config[Tile_Id].ADCBlock_Analog_Config[Block_Id].BlockAvailable;
+	}
 
 RETURN_PATH:
 	return IsDigitalPathAvail;


### PR DESCRIPTION
…s read 0Older RFdc IP generations (Gen1 XCZU27DR) do not populate theTILES_ENABLED (0x00A0), ADC_PATHS_ENABLED (0x00A4) andDAC_PATHS_ENABLED (0x00A8) registers, so they read 0. Since ~2019the driver derives tile/block/digital-path availability solely fromthese registers, causing every tile/block to be reported as notavailable on such designs even though the converters exist and run.This restores the pre-2019 behaviour as a fallback: when the registerreads 0, availability is derived from the config structure instead.The fallback is never reached on modern hardware where the registersare properly populated, so there is no behavioural change for Gen3+.Signed-off-by: Ivan Bakusic ivan.bakusic@ericsson.com


